### PR TITLE
Move base test cases to their own dir & export them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Northwestern\\SysDev\\DynamicForms\\": "src/"
+            "Northwestern\\SysDev\\DynamicForms\\": "src/",
+            "Northwestern\\SysDev\\DynamicForms\\Tests\\Components\\TestCases\\": "tests/Components/TestCases"
         }
     },
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.179.1",
+            "version": "3.179.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "f4f2c01b53f71379a1ed8ccccf4305949a69ccbe"
+                "reference": "7d3490e35878d0884905fa0c1ab43ecf178c8d9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f4f2c01b53f71379a1ed8ccccf4305949a69ccbe",
-                "reference": "f4f2c01b53f71379a1ed8ccccf4305949a69ccbe",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7d3490e35878d0884905fa0c1ab43ecf178c8d9b",
+                "reference": "7d3490e35878d0884905fa0c1ab43ecf178c8d9b",
                 "shasum": ""
             },
             "require": {
@@ -92,9 +92,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.179.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.179.2"
             },
-            "time": "2021-04-29T18:17:25+00:00"
+            "time": "2021-04-30T19:46:52+00:00"
         },
         {
             "name": "brick/math",
@@ -925,16 +925,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.5.8",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf"
+                "reference": "19a9673b833cc37770439097b381d86cd125bfe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf",
-                "reference": "08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/19a9673b833cc37770439097b381d86cd125bfe8",
+                "reference": "19a9673b833cc37770439097b381d86cd125bfe8",
                 "shasum": ""
             },
             "require": {
@@ -1022,7 +1022,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-28T18:51:39+00:00"
+            "time": "2021-05-01T19:00:49+00:00"
         },
         {
             "name": "league/flysystem",
@@ -1334,16 +1334,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.46.0",
+            "version": "2.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4"
+                "reference": "606262fd8888b75317ba9461825a24fc34001e1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
-                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/606262fd8888b75317ba9461825a24fc34001e1e",
+                "reference": "606262fd8888b75317ba9461825a24fc34001e1e",
                 "shasum": ""
             },
             "require": {
@@ -1423,7 +1423,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-24T17:30:44+00:00"
+            "time": "2021-04-13T21:54:02+00:00"
         },
         {
             "name": "opis/closure",
@@ -1764,16 +1764,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -1797,7 +1797,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -1808,9 +1808,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -2153,16 +2153,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "35f039df40a3b335ebf310f244cb242b3a83ac8d"
+                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/35f039df40a3b335ebf310f244cb242b3a83ac8d",
-                "reference": "35f039df40a3b335ebf310f244cb242b3a83ac8d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/90374b8ed059325b49a29b55b3f8bb4062c87629",
+                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629",
                 "shasum": ""
             },
             "require": {
@@ -2230,7 +2230,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.6"
+                "source": "https://github.com/symfony/console/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -2246,20 +2246,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-28T09:42:18+00:00"
+            "time": "2021-04-19T14:07:32+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.2.4",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "f65f217b3314504a1ec99c2d6ef69016bb13490f"
+                "reference": "59a684f5ac454f066ecbe6daecce6719aed283fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f65f217b3314504a1ec99c2d6ef69016bb13490f",
-                "reference": "f65f217b3314504a1ec99c2d6ef69016bb13490f",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/59a684f5ac454f066ecbe6daecce6719aed283fb",
+                "reference": "59a684f5ac454f066ecbe6daecce6719aed283fb",
                 "shasum": ""
             },
             "require": {
@@ -2295,7 +2295,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.2.4"
+                "source": "https://github.com/symfony/css-selector/tree/v5.3.0-BETA1"
             },
             "funding": [
                 {
@@ -2311,7 +2311,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:01:46+00:00"
+            "time": "2021-04-07T16:07:52+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2382,16 +2382,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "bdb7fb4188da7f4211e4b88350ba0dfdad002b03"
+                "reference": "ea3ddbf67615e883ca7c33a4de61213789846782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/bdb7fb4188da7f4211e4b88350ba0dfdad002b03",
-                "reference": "bdb7fb4188da7f4211e4b88350ba0dfdad002b03",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/ea3ddbf67615e883ca7c33a4de61213789846782",
+                "reference": "ea3ddbf67615e883ca7c33a4de61213789846782",
                 "shasum": ""
             },
             "require": {
@@ -2431,7 +2431,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v5.2.6"
+                "source": "https://github.com/symfony/error-handler/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -2447,7 +2447,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-16T09:07:47+00:00"
+            "time": "2021-04-07T15:57:33+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2754,16 +2754,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.2.4",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "54499baea7f7418bce7b5ec92770fd0799e8e9bf"
+                "reference": "a416487a73bb9c9d120e9ba3a60547f4a3fb7a1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/54499baea7f7418bce7b5ec92770fd0799e8e9bf",
-                "reference": "54499baea7f7418bce7b5ec92770fd0799e8e9bf",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a416487a73bb9c9d120e9ba3a60547f4a3fb7a1f",
+                "reference": "a416487a73bb9c9d120e9ba3a60547f4a3fb7a1f",
                 "shasum": ""
             },
             "require": {
@@ -2807,7 +2807,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.2.4"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -2823,20 +2823,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-25T17:16:57+00:00"
+            "time": "2021-05-01T13:46:24+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f34de4c61ca46df73857f7f36b9a3805bdd7e3b2"
+                "reference": "1e9f6879f070f718e0055fbac232a56f67b8b6bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f34de4c61ca46df73857f7f36b9a3805bdd7e3b2",
-                "reference": "f34de4c61ca46df73857f7f36b9a3805bdd7e3b2",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1e9f6879f070f718e0055fbac232a56f67b8b6bd",
+                "reference": "1e9f6879f070f718e0055fbac232a56f67b8b6bd",
                 "shasum": ""
             },
             "require": {
@@ -2919,7 +2919,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.2.6"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -2935,20 +2935,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-29T05:16:58+00:00"
+            "time": "2021-05-01T14:53:15+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "1b2092244374cbe48ae733673f2ca0818b37197b"
+                "reference": "7af452bf51c46f18da00feb32e1ad36db9426515"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/1b2092244374cbe48ae733673f2ca0818b37197b",
-                "reference": "1b2092244374cbe48ae733673f2ca0818b37197b",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/7af452bf51c46f18da00feb32e1ad36db9426515",
+                "reference": "7af452bf51c46f18da00feb32e1ad36db9426515",
                 "shasum": ""
             },
             "require": {
@@ -3002,7 +3002,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.2.6"
+                "source": "https://github.com/symfony/mime/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -3018,7 +3018,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-12T13:18:39+00:00"
+            "time": "2021-04-29T20:47:09+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3751,16 +3751,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.2.4",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f"
+                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
-                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
+                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
                 "shasum": ""
             },
             "require": {
@@ -3793,7 +3793,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.2.4"
+                "source": "https://github.com/symfony/process/tree/v5.3.0-BETA1"
             },
             "funding": [
                 {
@@ -3809,20 +3809,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-04-08T10:27:02+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "31fba555f178afd04d54fd26953501b2c3f0c6e6"
+                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/31fba555f178afd04d54fd26953501b2c3f0c6e6",
-                "reference": "31fba555f178afd04d54fd26953501b2c3f0c6e6",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
+                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
                 "shasum": ""
             },
             "require": {
@@ -3845,7 +3845,6 @@
                 "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
-                "doctrine/annotations": "For using the annotation loader",
                 "symfony/config": "For using the all-in-one router or any loader",
                 "symfony/expression-language": "For using expression matching",
                 "symfony/http-foundation": "For using a Symfony Request object",
@@ -3883,7 +3882,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.2.6"
+                "source": "https://github.com/symfony/routing/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -3899,7 +3898,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-14T13:53:33+00:00"
+            "time": "2021-04-11T22:55:21+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4065,16 +4064,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "2cc7f45d96db9adfcf89adf4401d9dfed509f4e1"
+                "reference": "e37ece5242564bceea54d709eafc948377ec9749"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/2cc7f45d96db9adfcf89adf4401d9dfed509f4e1",
-                "reference": "2cc7f45d96db9adfcf89adf4401d9dfed509f4e1",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e37ece5242564bceea54d709eafc948377ec9749",
+                "reference": "e37ece5242564bceea54d709eafc948377ec9749",
                 "shasum": ""
             },
             "require": {
@@ -4138,7 +4137,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.2.6"
+                "source": "https://github.com/symfony/translation/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -4154,7 +4153,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T19:33:48+00:00"
+            "time": "2021-04-01T08:15:21+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -4236,16 +4235,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "89412a68ea2e675b4e44f260a5666729f77f668e"
+                "reference": "27cb9f7cfa3853c736425c7233a8f68814b19636"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/89412a68ea2e675b4e44f260a5666729f77f668e",
-                "reference": "89412a68ea2e675b4e44f260a5666729f77f668e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/27cb9f7cfa3853c736425c7233a8f68814b19636",
+                "reference": "27cb9f7cfa3853c736425c7233a8f68814b19636",
                 "shasum": ""
             },
             "require": {
@@ -4304,7 +4303,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.2.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -4320,7 +4319,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-28T09:42:18+00:00"
+            "time": "2021-04-19T14:07:32+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -6980,16 +6979,16 @@
         },
         {
             "name": "spatie/laravel-ray",
-            "version": "1.17.3",
+            "version": "1.17.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-ray.git",
-                "reference": "fc5d715f4dfdb6f4bfa42046b4d2ced0de326add"
+                "reference": "e48be16da1952ffca868c77f509a767d3fc632bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-ray/zipball/fc5d715f4dfdb6f4bfa42046b4d2ced0de326add",
-                "reference": "fc5d715f4dfdb6f4bfa42046b4d2ced0de326add",
+                "url": "https://api.github.com/repos/spatie/laravel-ray/zipball/e48be16da1952ffca868c77f509a767d3fc632bc",
+                "reference": "e48be16da1952ffca868c77f509a767d3fc632bc",
                 "shasum": ""
             },
             "require": {
@@ -7044,7 +7043,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-ray/issues",
-                "source": "https://github.com/spatie/laravel-ray/tree/1.17.3"
+                "source": "https://github.com/spatie/laravel-ray/tree/1.17.4"
             },
             "funding": [
                 {
@@ -7056,7 +7055,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-04-29T12:29:14+00:00"
+            "time": "2021-04-30T08:20:24+00:00"
         },
         {
             "name": "spatie/macroable",
@@ -7185,16 +7184,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.2.4",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "212d54675bf203ff8aef7d8cee8eecfb72f4a263"
+                "reference": "3817662ada105c8c4d1afdb4ec003003efd1d8d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/212d54675bf203ff8aef7d8cee8eecfb72f4a263",
-                "reference": "212d54675bf203ff8aef7d8cee8eecfb72f4a263",
+                "url": "https://api.github.com/repos/symfony/config/zipball/3817662ada105c8c4d1afdb4ec003003efd1d8d8",
+                "reference": "3817662ada105c8c4d1afdb4ec003003efd1d8d8",
                 "shasum": ""
             },
             "require": {
@@ -7243,7 +7242,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.2.4"
+                "source": "https://github.com/symfony/config/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -7259,20 +7258,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-23T23:58:19+00:00"
+            "time": "2021-04-07T16:07:52+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8c86a82f51658188119e62cff0a050a12d09836f"
+                "reference": "056e92acc21d977c37e6ea8e97374b2a6c8551b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8c86a82f51658188119e62cff0a050a12d09836f",
-                "reference": "8c86a82f51658188119e62cff0a050a12d09836f",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/056e92acc21d977c37e6ea8e97374b2a6c8551b0",
+                "reference": "056e92acc21d977c37e6ea8e97374b2a6c8551b0",
                 "shasum": ""
             },
             "require": {
@@ -7305,7 +7304,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.6"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -7321,20 +7320,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-28T14:30:26+00:00"
+            "time": "2021-04-01T10:42:13+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.2.4",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "b12274acfab9d9850c52583d136a24398cdf1a0c"
+                "reference": "d99310c33e833def36419c284f60e8027d359678"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b12274acfab9d9850c52583d136a24398cdf1a0c",
-                "reference": "b12274acfab9d9850c52583d136a24398cdf1a0c",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/d99310c33e833def36419c284f60e8027d359678",
+                "reference": "d99310c33e833def36419c284f60e8027d359678",
                 "shasum": ""
             },
             "require": {
@@ -7367,7 +7366,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.2.4"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.3.0-BETA1"
             },
             "funding": [
                 {
@@ -7383,20 +7382,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-03-29T15:28:41+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.2.5",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "298a08ddda623485208506fcee08817807a251dd"
+                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/298a08ddda623485208506fcee08817807a251dd",
-                "reference": "298a08ddda623485208506fcee08817807a251dd",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
+                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
                 "shasum": ""
             },
             "require": {
@@ -7442,7 +7441,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.2.5"
+                "source": "https://github.com/symfony/yaml/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -7458,7 +7457,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-06T07:59:01+00:00"
+            "time": "2021-04-29T20:47:09+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/Components/Inputs/AddressTest.php
+++ b/tests/Components/Inputs/AddressTest.php
@@ -5,7 +5,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Address;
 use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Address

--- a/tests/Components/Inputs/ButtonTest.php
+++ b/tests/Components/Inputs/ButtonTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Button;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Button

--- a/tests/Components/Inputs/CheckboxTest.php
+++ b/tests/Components/Inputs/CheckboxTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Checkbox;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Checkbox

--- a/tests/Components/Inputs/CurrencyTest.php
+++ b/tests/Components/Inputs/CurrencyTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Currency;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Currency

--- a/tests/Components/Inputs/DateTimeTest.php
+++ b/tests/Components/Inputs/DateTimeTest.php
@@ -5,7 +5,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 use Illuminate\Support\Carbon;
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\DateTime;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\DateTime

--- a/tests/Components/Inputs/DayTest.php
+++ b/tests/Components/Inputs/DayTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Day;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Day

--- a/tests/Components/Inputs/EmailTest.php
+++ b/tests/Components/Inputs/EmailTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Email;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Email

--- a/tests/Components/Inputs/FileTest.php
+++ b/tests/Components/Inputs/FileTest.php
@@ -5,7 +5,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 use Illuminate\Support\Arr;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\File;
 use Northwestern\SysDev\DynamicForms\Storage\S3Driver;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\File

--- a/tests/Components/Inputs/NumberTest.php
+++ b/tests/Components/Inputs/NumberTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Number;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Number

--- a/tests/Components/Inputs/PhoneNumberTest.php
+++ b/tests/Components/Inputs/PhoneNumberTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\PhoneNumber;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\PhoneNumber

--- a/tests/Components/Inputs/RadioTest.php
+++ b/tests/Components/Inputs/RadioTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Radio;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Radio

--- a/tests/Components/Inputs/SelectBoxesTest.php
+++ b/tests/Components/Inputs/SelectBoxesTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\SelectBoxes;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\SelectBoxes

--- a/tests/Components/Inputs/SelectTest.php
+++ b/tests/Components/Inputs/SelectTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Select;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Select

--- a/tests/Components/Inputs/SignatureTest.php
+++ b/tests/Components/Inputs/SignatureTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Signature;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Signature

--- a/tests/Components/Inputs/SurveyTest.php
+++ b/tests/Components/Inputs/SurveyTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Survey;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Survey

--- a/tests/Components/Inputs/TextareaTest.php
+++ b/tests/Components/Inputs/TextareaTest.php
@@ -5,7 +5,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Textarea;
 use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Textarea

--- a/tests/Components/Inputs/TextfieldTest.php
+++ b/tests/Components/Inputs/TextfieldTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Textfield;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Textfield

--- a/tests/Components/Inputs/TimeTest.php
+++ b/tests/Components/Inputs/TimeTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Time;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Time

--- a/tests/Components/Inputs/UrlTest.php
+++ b/tests/Components/Inputs/UrlTest.php
@@ -4,7 +4,7 @@ namespace Northwestern\SysDev\DynamicForms\Tests\Components\Inputs;
 
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Url;
-use Northwestern\SysDev\DynamicForms\Tests\Components\InputComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Inputs\Url

--- a/tests/Components/Layout/ColumnsTest.php
+++ b/tests/Components/Layout/ColumnsTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Layout;
 
 use Northwestern\SysDev\DynamicForms\Components\Layout\Columns;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Layout\Columns

--- a/tests/Components/Layout/ContentTest.php
+++ b/tests/Components/Layout/ContentTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Layout;
 
 use Northwestern\SysDev\DynamicForms\Components\Layout\Content;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Layout\Content

--- a/tests/Components/Layout/FieldsetTest.php
+++ b/tests/Components/Layout/FieldsetTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Layout;
 
 use Northwestern\SysDev\DynamicForms\Components\Layout\Fieldset;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Layout\Fieldset

--- a/tests/Components/Layout/HtmlElementTest.php
+++ b/tests/Components/Layout/HtmlElementTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Layout;
 
 use Northwestern\SysDev\DynamicForms\Components\Layout\HtmlElement;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Layout\HtmlElement

--- a/tests/Components/Layout/PanelTest.php
+++ b/tests/Components/Layout/PanelTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Layout;
 
 use Northwestern\SysDev\DynamicForms\Components\Layout\Panel;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Layout\Panel

--- a/tests/Components/Layout/TableTest.php
+++ b/tests/Components/Layout/TableTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Layout;
 
 use Northwestern\SysDev\DynamicForms\Components\Layout\Table;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Layout\Table

--- a/tests/Components/Layout/WellTest.php
+++ b/tests/Components/Layout/WellTest.php
@@ -3,7 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Tests\Components\Layout;
 
 use Northwestern\SysDev\DynamicForms\Components\Layout\Well;
-use Northwestern\SysDev\DynamicForms\Tests\Components\BaseComponentTestCase;
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\Layout\Well

--- a/tests/Components/TestCases/BaseComponentTestCase.php
+++ b/tests/Components/TestCases/BaseComponentTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northwestern\SysDev\DynamicForms\Tests\Components;
+namespace Northwestern\SysDev\DynamicForms\Tests\Components\TestCases;
 
 use Northwestern\SysDev\DynamicForms\Components\ComponentInterface;
 use Orchestra\Testbench\TestCase;

--- a/tests/Components/TestCases/InputComponentTestCase.php
+++ b/tests/Components/TestCases/InputComponentTestCase.php
@@ -1,11 +1,14 @@
 <?php
 
-namespace Northwestern\SysDev\DynamicForms\Tests\Components;
+namespace Northwestern\SysDev\DynamicForms\Tests\Components\TestCases;
+
+use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\BaseComponentTestCase;
+use function app;
 
 /**
  * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Components\BaseComponent
  */
-class InputComponentTestCase extends BaseComponentTestCase
+abstract class InputComponentTestCase extends BaseComponentTestCase
 {
     /**
      * @covers ::canValidate


### PR DESCRIPTION
The directory search component extends the InputTestCase, which is how I intended for folks to do testing on their stuff.

Moving it into its own directory lets me expose it to the autoloader without exposing too much.