### PR TITLE
Permit components to validate-as-multiple in single mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - The methods from the `HandlesDynamicFormsStorage` trait have been renamed.
-    - The route stub file has been updated accordingly. Please see the upgrading guide in the docs site for resolving this change. 
+    - The route stub file has been updated accordingly. Please see the upgrading guide in the docs site for resolving this change.
+- `BaseComponent` now uses a new `hasMultipleValuesForValidation()` method to determine if a field in single-value mode should be validated in multi-value mode.
 
 ### Fixed
 - The `ComponentRegistry` now consistently registers components without a leading slash in namespaces. 

--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -69,6 +69,18 @@ abstract class BaseComponent implements ComponentInterface
         return $this->hasMultipleValues;
     }
 
+    /**
+     * Informs the validation code if this should be treated as a multi-value field.
+     *
+     * There are cases where components always store data as multiple values, even in single-
+     * value mode. The validator needs to handle that correctly, but we do not want to inadvertently
+     * perform a transformation that makes the data incompatible with viewing/editing it again.
+     */
+    protected function hasMultipleValuesForValidation(): bool
+    {
+        return $this->hasMultipleValues();
+    }
+
     public function hasConditional(): bool
     {
         return $this->conditional || $this->customConditional;
@@ -121,7 +133,7 @@ abstract class BaseComponent implements ComponentInterface
             return $bag;
         }
 
-        if ($this->hasMultipleValues()) {
+        if ($this->hasMultipleValuesForValidation()) {
             foreach ($this->submissionValue() as $index => $submissionValue) {
                 $bag = $this->mergeErrorBags($bag, $this->processValidations(
                     $this->errorLabel ?? sprintf('%s %s', $fieldKey, $index),
@@ -205,7 +217,7 @@ abstract class BaseComponent implements ComponentInterface
      */
     protected function postProcessValidationsForMultiple(string $fieldKey): MessageBag
     {
-        if (! $this->hasMultipleValues()) {
+        if (! $this->hasMultipleValuesForValidation()) {
             throw new InvalidDefinitionError(
                 sprintf('%s called but component is multiple => false; cannot process', __METHOD__),
                 $this->key()

--- a/src/Components/Inputs/File.php
+++ b/src/Components/Inputs/File.php
@@ -41,16 +41,12 @@ class File extends BaseComponent implements UploadInterface
         $this->storage = $storage;
     }
 
-    public function submissionValue(): mixed
+    /**
+     * Files always come in an array, even when in single-value mode.
+     */
+    protected function hasMultipleValuesForValidation(): bool
     {
-        if ($this->hasMultipleValues) {
-            return parent::submissionValue();
-        }
-        if ($this->submissionValue == []) {
-            return null;
-        }
-
-        return parent::submissionValue()[0] ?? parent::submissionValue();
+        return true;
     }
 
     /**

--- a/tests/Components/Inputs/FileTest.php
+++ b/tests/Components/Inputs/FileTest.php
@@ -125,7 +125,9 @@ class FileTest extends InputComponentTestCase
 
     public function submissionValueProvider(): array
     {
-        return [];
+        return [
+            'empty passes through' => [null, [], []],
+        ];
     }
 
     protected function getComponent(


### PR DESCRIPTION
## Overview
<!-- 
Provide a brief overview of your changes. Focus on technical aspects -- the JIRA ticket # should be in your title, so people can refer to that for functional requirements.

A screenshot is worth a thousand words -- pictures of UI changes are really good to include.

When you open the PR, create it as a draft pull request if you aren't done & don't want changes merged. Opening your PR early is a great way to get feedback before you've gone too far down a path!
-->
The File component's validated `submissionValue()` returns data that is structured differently from the JSON submission document.

This causes form.io to be unable to display/edit files when shown after saving, if you're persisting the validated/cleaned data.

I resolve this by adding a new method for `validate()` to use when determining if we need to validate in single or multi-value mode. File forces itself to always be validated as multiple values, but is still presenting to the outside world as a single-value field when configured that way.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [x] `tests/` added or updated
- [x] CHANGELOG.md's *Unreleased* section is updated
- [x] Documentation is updated
