### PR TITLE
Swap to Quill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changes
+
+Set the default TextArea editor to Quill, and removed support for CKEDitor
+
 ## [v0.4.0 - 2021-07-29]
 ### Added
 - Support for JSONLogic (augmented with lodash) for conditional form fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [v0.5.0 - 2021-11-03]
 ### Changes
-
-Set the default TextArea editor to Quill, and removed support for CKEDitor
+- Set the default TextArea editor to Quill, and removed support for CKEDitor.
 
 ## [v0.4.0 - 2021-07-29]
 ### Added

--- a/dist/defaults.js
+++ b/dist/defaults.js
@@ -124,7 +124,7 @@ export default {
                 key: 'display',
                 ignore: false,
                 components: [
-                    { key: 'editor', defaultValue: 'ckeditor', disabled: true }, // do not set hidden, it won't change to ckeditor if you do that
+                    { key: 'editor', defaultValue: 'quill', disabled: true }, // do not set hidden, it won't change if you do that
                     { key: 'wysiwyg', ignore: true },
                 ],
             },

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,5 +1,32 @@
 # Upgrading
 
+## Unreleased
+
+This version switches the default editor to Quill (and removes support for CKEditor)
+
+To enable support, edit the `resources/js/formio/default.js` file. The `textarea` function has a section default editor swithc that from ckeditor to quill:
+
+```js
+       textarea: [
+    {
+        key: 'display',
+        ignore: false,
+        components: [
+            { key: 'editor', defaultValue: 'quill', disabled: true }, // do not set hidden, it won't change to ckeditor if you do that
+            { key: 'wysiwyg', ignore: true },
+        ],
+    },
+    {
+        key: 'data',
+        ignore: false,
+        components: [
+            { key: 'inputFormat', defaultValue: 'html', disabled: true },
+        ],
+    }
+],
+```
+
+
 ## v0.4.0
 This version adds support for JSONLogic conditionals.
 

--- a/src/Components/Inputs/Textarea.php
+++ b/src/Components/Inputs/Textarea.php
@@ -12,15 +12,15 @@ class Textarea extends Textfield
     /** * @var string Unsupported ACE editor */
     const EDITOR_ACE = 'ace';
 
-    /** * @var string Unsupported Quill editor */
+    /** * @var string Supported Quill editor */
     const EDITOR_QUILL = 'quill';
 
-    /** @var string */
+    /** @var string  Unsupported CKEditor editor*/
     const EDITOR_CKEDITOR = 'ckeditor';
 
     /** @var string[] Supported editors */
     const SUPPORTED_EDITORS = [
-        self::EDITOR_CKEDITOR,
+        self::EDITOR_QUILL
     ];
 
     public function __construct(

--- a/src/Components/Inputs/Textarea.php
+++ b/src/Components/Inputs/Textarea.php
@@ -15,12 +15,12 @@ class Textarea extends Textfield
     /** * @var string Supported Quill editor */
     const EDITOR_QUILL = 'quill';
 
-    /** @var string  Unsupported CKEditor editor*/
+    /** @var string Unsupported CKEditor editor */
     const EDITOR_CKEDITOR = 'ckeditor';
 
     /** @var string[] Supported editors */
     const SUPPORTED_EDITORS = [
-        self::EDITOR_QUILL
+        self::EDITOR_QUILL,
     ];
 
     public function __construct(

--- a/tests/Components/Inputs/TextareaTest.php
+++ b/tests/Components/Inputs/TextareaTest.php
@@ -13,7 +13,7 @@ use Northwestern\SysDev\DynamicForms\Tests\Components\TestCases\InputComponentTe
 class TextareaTest extends InputComponentTestCase
 {
     protected string $componentClass = Textarea::class;
-    protected array $defaultAdditional = ['editor' => Textarea::EDITOR_CKEDITOR];
+    protected array $defaultAdditional = ['editor' => Textarea::EDITOR_QUILL];
 
     public function testUnsupportedEditorThrowsError(): void
     {

--- a/tests/Fixtures/complex_definition.json
+++ b/tests/Fixtures/complex_definition.json
@@ -269,7 +269,7 @@
         },
         {
             "label":"Proposal",
-            "editor":"ckeditor",
+            "editor":"quill",
             "hideLabel":true,
             "tableView":true,
             "validate":{

--- a/tests/Fixtures/time_definition.json
+++ b/tests/Fixtures/time_definition.json
@@ -165,7 +165,7 @@
         },
         {
             "label":"Proposal ",
-            "editor":"ckeditor",
+            "editor":"quill",
             "hideLabel":true,
             "validate":{
                 "required":true


### PR DESCRIPTION
## Overview
Set the default TextArea editor to Quill, and removed support for CKEDitor

## Checklist

- [X] `tests/` added or updated
- [X] CHANGELOG.md's *Unreleased* section is updated
- [X] Documentation is updated
