### PR TITLE
Support S3 uploads with a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+## [v0.5.4 - 2021-02-04]
+### Fixes
+- File components that use S3 and have a directory set will pass server-side validations now.
+
 ## [v0.5.3 - 2022-01-29]
 ### Fixes
 - Numeric values for `Select` & `Radio` components no longer cause the validation to fail.

--- a/src/Storage/S3Driver.php
+++ b/src/Storage/S3Driver.php
@@ -140,12 +140,12 @@ class S3Driver implements StorageInterface
          * Laravel's route() helper will provide a URL-encoded URL, but Formio will not. Rectify the difference
          * before trying to validate.
          */
-        $expectedUrl = urldecode(route('dynamic-forms.S3-file-redirect', ['fileKey' => $value['name']]));
-        if ($value['name'] != $value['key'] || $expectedUrl != $value['url']) {
+        $expectedUrl = urldecode(route('dynamic-forms.S3-file-redirect', ['fileKey' => $value['key']]));
+        if ($expectedUrl != $value['url']) {
             return false;
         }
 
-        return $this->findObject($value['name']);
+        return $this->findObject($value['key']);
     }
 
     public static function getStorageMethod(): string

--- a/tests/Components/Inputs/FileTest.php
+++ b/tests/Components/Inputs/FileTest.php
@@ -115,8 +115,6 @@ class FileTest extends InputComponentTestCase
             'valid file passes' => [[], $filePASS, true],
             'required passes' => [['required' => true], $filePASS, true],
             'required fails' => [['required' => true], [], false],
-            'FileExists fails from name consistency check' => [[], $fileNameCheckFail, false],
-            'FileExists fails from key consistency check' => [[], $fileKeyCheckFail, false],
             'FileExists fails from url consistency check' => [[], $fileURLCheckFail, false],
             'FileExists fails from file not found ' => [[], $fileNotFoundCheckFail, false],
             'FileExists passes' => [[], $filePASS, true],

--- a/tests/Rules/FileExistsTest.php
+++ b/tests/Rules/FileExistsTest.php
@@ -42,6 +42,11 @@ class FileExistsTest extends TestCase
             'storage' => S3Driver::STORAGE_S3,
         ];
 
+        $validS3WithPath = array_merge($validS3, [
+            'key' => 'folder/foo1',
+            'url' => 'http://localhost/dynamic-forms/storage/s3/folder/foo1',
+        ]);
+
         $validURL = [
             'name' => 'foo1',
             'url' => 'http://localhost/dynamic-forms/storage/url?baseUrl=https%3A%2F%2Fapi.form.io&project=&form=/foo1', // should match name with additional data fields added on
@@ -56,8 +61,8 @@ class FileExistsTest extends TestCase
             'valid S3' => [$validS3, true, true],
             'missing field S3' => [['storage' => S3Driver::STORAGE_S3], true, false],
             'unexpected url S3' => [array_merge($validS3, ['url' => '/dog']), true, false],
-            'not consistent S3' => [array_merge($validS3, ['name' => 'dog']), true, false],
             'file does not exist S3' => [$validS3, false, false],
+            'in s3 with a subfolder' => [$validS3WithPath, true, true],
 
             // file, should exist in storage, passes
             'valid URL' => [$validURL, true, true],


### PR DESCRIPTION
## Overview
<!-- 
Provide a brief overview of your changes. Focus on technical aspects -- the JIRA ticket # should be in your title, so people can refer to that for functional requirements.

A screenshot is worth a thousand words -- pictures of UI changes are really good to include.

When you open the PR, create it as a draft pull request if you aren't done & don't want changes merged. Opening your PR early is a great way to get feedback before you've gone too far down a path!
-->
Currently, the `dir` key isn't being properly supported when uploading to S3. The UI works fine, but the server-side validations fail.

We're checking a couple pieces of data formio sends to the server for consistency, and they just aren't intended to be consistent in this case -- the file `name` is the basename, but `key` is the full S3 object key.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [x] `tests/` added or updated
- [x] CHANGELOG.md's *Unreleased* section is updated
- [x] Documentation is updated
