### PR TITLE
Fix label validation bug

### DIFF
--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -148,7 +148,8 @@ abstract class BaseComponent implements ComponentInterface
 
     public function validate(): MessageBag
     {
-        $fieldKey = $this->errorLabel() ?? $this->label() ?? $this->key();
+        $fieldLabel = $this->errorLabel() ?? $this->label() ?? $this->key();
+
         $validator = app()->make('validator');
         $bag = new MessageBagImpl;
 
@@ -159,18 +160,19 @@ abstract class BaseComponent implements ComponentInterface
         if ($this->hasMultipleValuesForValidation()) {
             foreach ($this->submissionValue() as $index => $submissionValue) {
                 $bag = $this->mergeErrorBags($bag, $this->processValidations(
-                    $this->errorLabel ?? sprintf('%s %s', $fieldKey, $index),
+                    $this->key(),
+                    $this->errorLabel() ?? sprintf('%s (%s)', $fieldLabel, $index + 1),
                     $submissionValue,
                     $validator
                 ));
             }
 
-            return $bag->merge($this->postProcessValidationsForMultiple($fieldKey));
+            return $bag->merge($this->postProcessValidationsForMultiple($this->key()));
         }
 
         return $this->mergeErrorBags(
             new MessageBagImpl,
-            $this->processValidations($fieldKey, $this->submissionValue(), $validator)
+            $this->processValidations($this->key(), $fieldLabel, $this->submissionValue(), $validator)
         );
     }
 
@@ -224,7 +226,7 @@ abstract class BaseComponent implements ComponentInterface
      * @param Factory $validator Illuminate validation factory, usage of which is optional (but common!)
      * @return MessageBag
      */
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         throw new ValidationNotImplementedError($this->type());
     }

--- a/src/Components/Inputs/Address.php
+++ b/src/Components/Inputs/Address.php
@@ -49,7 +49,7 @@ class Address extends BaseComponent
         }
     }
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         // This isn't a scalar, so our typical RuleBag pattern does not work here.
 
@@ -62,6 +62,8 @@ class Address extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules,
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 }

--- a/src/Components/Inputs/Checkbox.php
+++ b/src/Components/Inputs/Checkbox.php
@@ -11,7 +11,7 @@ class Checkbox extends BaseComponent
 {
     const TYPE = 'checkbox';
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['boolean']);
         $rules->addIf('accepted', $this->validation('required') === true);
@@ -19,6 +19,8 @@ class Checkbox extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 }

--- a/src/Components/Inputs/Currency.php
+++ b/src/Components/Inputs/Currency.php
@@ -11,7 +11,7 @@ class Currency extends BaseComponent
 {
     const TYPE = 'currency';
 
-    public function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    public function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['numeric']);
 
@@ -20,6 +20,8 @@ class Currency extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 

--- a/src/Components/Inputs/DateTime.php
+++ b/src/Components/Inputs/DateTime.php
@@ -39,7 +39,7 @@ class DateTime extends BaseComponent
             : $cleaner($this->submissionValue);
     }
 
-    public function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    public function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         // Turn this back into a string so it works w/ the Laravel validators
         $submissionValue = $submissionValue?->toAtomString();
@@ -63,6 +63,8 @@ class DateTime extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 }

--- a/src/Components/Inputs/Day.php
+++ b/src/Components/Inputs/Day.php
@@ -12,7 +12,7 @@ class Day extends BaseComponent
 {
     const TYPE = 'day';
 
-    public function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    public function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $dateParts = $this->getDateParts($submissionValue);
 
@@ -67,6 +67,8 @@ class Day extends BaseComponent
         $dateBag = $validator->make(
             [$fieldKey => $submissionValue],
             $dateRules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
 
         return $partsBag->merge($dateBag);

--- a/src/Components/Inputs/Email.php
+++ b/src/Components/Inputs/Email.php
@@ -10,13 +10,13 @@ class Email extends Textfield
 {
     const TYPE = 'email';
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['string']);
 
         // This has all the same stuff as a textfield (including, weirdly, word length),
         // so process it through there first.
-        $bag = parent::processValidations($fieldKey, $submissionValue, $validator);
+        $bag = parent::processValidations($fieldKey, $fieldLabel, $submissionValue, $validator);
 
         // And then email just adds a requirement that the string be a valid-looking email address,
         // assuming the data is present. The nullable rule should make email pass if it's
@@ -27,6 +27,8 @@ class Email extends Textfield
         $valid = $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         );
 
         return $bag->merge($valid->messages());

--- a/src/Components/Inputs/File.php
+++ b/src/Components/Inputs/File.php
@@ -15,7 +15,7 @@ class File extends BaseComponent implements UploadInterface
     const TYPE = 'file';
     protected StorageInterface $storage;
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, []);
         if ($this->validation('required')) {
@@ -28,6 +28,8 @@ class File extends BaseComponent implements UploadInterface
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 

--- a/src/Components/Inputs/Number.php
+++ b/src/Components/Inputs/Number.php
@@ -12,7 +12,7 @@ class Number extends BaseComponent
 {
     const TYPE = 'number';
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $fieldKey = $this->label() ?? $this->key();
 
@@ -24,6 +24,8 @@ class Number extends BaseComponent
         $validator = app()->make('validator')->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         );
 
         return $validator->messages();

--- a/src/Components/Inputs/PhoneNumber.php
+++ b/src/Components/Inputs/PhoneNumber.php
@@ -11,7 +11,7 @@ class PhoneNumber extends BaseComponent
 {
     const TYPE = 'phoneNumber';
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['string']);
 
@@ -21,6 +21,8 @@ class PhoneNumber extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 }

--- a/src/Components/Inputs/Radio.php
+++ b/src/Components/Inputs/Radio.php
@@ -59,7 +59,7 @@ class Radio extends BaseComponent
         return $this->radioChoices;
     }
 
-    public function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    public function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['string']);
 
@@ -75,6 +75,8 @@ class Radio extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 }

--- a/src/Components/Inputs/Select.php
+++ b/src/Components/Inputs/Select.php
@@ -79,7 +79,7 @@ class Select extends BaseComponent
         return is_scalar($value) ? (string) $value : $value;
     }
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['string']);
 
@@ -92,6 +92,8 @@ class Select extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 

--- a/src/Components/Inputs/SelectBoxes.php
+++ b/src/Components/Inputs/SelectBoxes.php
@@ -63,7 +63,7 @@ class SelectBoxes extends BaseComponent
      * @param Factory $validator
      * @return MessageBag
      */
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $bag = new MessageBagImpl;
 
@@ -78,12 +78,12 @@ class SelectBoxes extends BaseComponent
 
         if ($minSelected !== null && $checkedNum < $minSelected) {
             $message = sprintf('You must select at least %s items.', $minSelected);
-            $bag->add($fieldKey, Arr::get($this->additional, 'minSelectedCountMessage', $message));
+            $bag->add($fieldLabel, Arr::get($this->additional, 'minSelectedCountMessage', $message));
         }
 
         if ($maxSelected !== null && $checkedNum > $maxSelected) {
             $message = sprintf('You cannot select more than %s items.', $minSelected);
-            $bag->add($fieldKey, Arr::get($this->additional, 'maxSelectedCountMessage', $message));
+            $bag->add($fieldLabel, Arr::get($this->additional, 'maxSelectedCountMessage', $message));
         }
 
         return $bag;

--- a/src/Components/Inputs/Signature.php
+++ b/src/Components/Inputs/Signature.php
@@ -26,7 +26,7 @@ class Signature extends BaseComponent
      * @param Factory $validator
      * @return MessageBag
      */
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['string']);
 
@@ -43,6 +43,8 @@ class Signature extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 

--- a/src/Components/Inputs/Survey.php
+++ b/src/Components/Inputs/Survey.php
@@ -62,7 +62,7 @@ class Survey extends BaseComponent
             : $cleaner($this->submissionValue);
     }
 
-    public function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    public function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         // This isn't a scalar, so our typical RuleBag pattern does not apply here.
         $rules = [];
@@ -81,7 +81,9 @@ class Survey extends BaseComponent
 
         return $validator->make(
             [$fieldKey => $submissionValue],
-            $rules
+            $rules,
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 }

--- a/src/Components/Inputs/Textfield.php
+++ b/src/Components/Inputs/Textfield.php
@@ -12,7 +12,7 @@ class Textfield extends BaseComponent
 {
     const TYPE = 'textfield';
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['string']);
         $rules->addIf('required', $this->validation('required') === true);
@@ -34,6 +34,8 @@ class Textfield extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel],
         )->messages();
     }
 }

--- a/src/Components/Inputs/Time.php
+++ b/src/Components/Inputs/Time.php
@@ -12,7 +12,7 @@ class Time extends BaseComponent
 {
     const TYPE = 'time';
 
-    public function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    public function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $rules = new RuleBag($fieldKey, ['string']);
 
@@ -22,6 +22,8 @@ class Time extends BaseComponent
         return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         )->messages();
     }
 }

--- a/src/Components/Inputs/Url.php
+++ b/src/Components/Inputs/Url.php
@@ -10,14 +10,14 @@ class Url extends Textfield
 {
     const TYPE = 'url';
 
-    protected function processValidations(string $fieldKey, mixed $submissionValue, Factory $validator): MessageBag
+    protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
         $fieldKey = $this->label() ?? $this->key();
         $rules = new RuleBag($fieldKey, ['string']);
 
         // This has all the same stuff as a textfield (including, weirdly, word length),
         // so process it through there first.
-        $bag = parent::processValidations($fieldKey, $submissionValue, $validator);
+        $bag = parent::processValidations($fieldKey, $fieldLabel, $submissionValue, $validator);
 
         // And then URL just adds a requirement that the string be a valid-looking URL,
         // assuming the data is present. The nullable rule should make URL pass if it's
@@ -28,6 +28,8 @@ class Url extends Textfield
         $validator = app()->make('validator')->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
+            [],
+            [$fieldKey => $fieldLabel]
         );
 
         return $bag->merge($validator->messages());

--- a/tests/Fixtures/field_name_ends_with_dot.json
+++ b/tests/Fixtures/field_name_ends_with_dot.json
@@ -1,0 +1,17 @@
+{
+    "components": [
+        {
+            "label": "Please explain in detail why application for a URG was not possible.",
+            "editor": "quill",
+            "isUploadEnabled": false,
+            "clearOnHide": false,
+            "validate": {
+                "required": true
+            },
+            "key": "pleaseExplainInDetailWhyApplicationForAUrgWasNotPossible",
+            "type": "textarea",
+            "input": true,
+            "tableView": true
+        }
+    ]
+}

--- a/tests/Forms/ValidatedFormTest.php
+++ b/tests/Forms/ValidatedFormTest.php
@@ -2,7 +2,6 @@
 
 namespace Northwestern\SysDev\DynamicForms\Tests\Forms;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Northwestern\SysDev\DynamicForms\Components\CaseEnum;
 use Northwestern\SysDev\DynamicForms\Components\Inputs\Textfield;
@@ -181,6 +180,12 @@ class ValidatedFormTest extends TestCase
                 ['totalCost' => '', 'otherFunding' => 10, 'netAmount' => null],
                 false,
                 ['totalCost' => null, 'otherFunding' => 10, 'netAmount' => -10],
+            ],
+            'validation-key-significant characters in the label do not break validation' => [
+                $components('field_name_ends_with_dot.json'),
+                ['pleaseExplainInDetailWhyApplicationForAUrgWasNotPossible' => 'bla'],
+                true,
+                ['pleaseExplainInDetailWhyApplicationForAUrgWasNotPossible' => 'bla'],
             ],
         ];
     }


### PR DESCRIPTION
## Overview
<!-- 
Provide a brief overview of your changes. Focus on technical aspects -- the JIRA ticket # should be in your title, so people can refer to that for functional requirements.

A screenshot is worth a thousand words -- pictures of UI changes are really good to include.

When you open the PR, create it as a draft pull request if you aren't done & don't want changes merged. Opening your PR early is a great way to get feedback before you've gone too far down a path!
-->
The component label is being used by the Laravel `Validation` service by every component. This was done to make the label show up in the error message.

However, if the label ends in a dot (`.`), the validator expects to be evaluating an array key underneath the field, and the validation will always fail. There's probably a similarly broken behaviour involving an asterisk (`*`).

This corrects how dynamic-forms interacts with the Validation service so that the key is used in the rules/data array instead of the label. The label is provided separately so it can generate the correct messages.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [x] `tests/` added or updated
- [x] CHANGELOG.md's *Unreleased* section is updated
- [x] Documentation is updated
