### PR TITLE
Fix keys for survey questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+## [v0.8.2 - 2022-07-01]
+- Fixes `Survey` components failing to validate if a question's `value` included a dot (.) character.
+
 ## [v0.8.1 - 2022-05-11]
 ### Fixes
 - The `ValidatedForm::allFiles()` method would not return files if the key contained a folder prefix. This has been corrected.

--- a/tests/Components/Inputs/SurveyTest.php
+++ b/tests/Components/Inputs/SurveyTest.php
@@ -16,6 +16,7 @@ class SurveyTest extends InputComponentTestCase
         'questions' => [
             ['label' => 'Question 1', 'value' => 'q1'],
             ['label' => 'Question 2', 'value' => 'q2'],
+            ['label' => 'Question 3 (i.e. foo bar)', 'value' => 'Question 3 (i.e. foo bar)'],
         ],
         'values' => [
             ['label' => 'Answer 1', 'value' => 'a1'],
@@ -29,7 +30,7 @@ class SurveyTest extends InputComponentTestCase
     public function testQuestions(): void
     {
         $this->assertEquals(
-            ['q1', 'q2'],
+            ['q1', 'q2', 'Question 3 (i.e. foo bar)'],
             $this->getSurvey()->questions()
         );
     }
@@ -60,18 +61,18 @@ class SurveyTest extends InputComponentTestCase
     public function validationsProvider(): array
     {
         return [
-            'empty data passes' => [[], ['q1' => '', 'q2' => ''], true],
-            'invalid value fails' => [[], ['q1' => 'invalid', 'q2' => 'a1'], false],
-            'required passes' => [['required' => true], ['q1' => 'a2', 'q2' => 'a1'], true],
-            'one missing - required fails' => [['required' => true], ['qa' => '', 'q2' => 'a1'], false],
-            'all missing - required fails' => [['required' => true], ['qa' => '', 'q2' => ''], false],
+            'empty data passes' => [[], ['q1' => '', 'q2' => '', 'Question 3 (i.e. foo bar)' => ''], true],
+            'invalid value fails' => [[], ['q1' => 'invalid', 'q2' => 'a1', 'Question 3 (i.e. foo bar)' => 'a1'], false],
+            'required passes' => [['required' => true], ['q1' => 'a2', 'q2' => 'a1', 'Question 3 (i.e. foo bar)' => 'a1'], true],
+            'one missing - required fails' => [['required' => true], ['qa' => '', 'q2' => 'a1', 'Question 3 (i.e. foo bar)' => 'a1'], false],
+            'all missing - required fails' => [['required' => true], ['qa' => '', 'q2' => '', 'Question 3 (i.e. foo bar)' => ''], false],
 
         ];
     }
 
     public function submissionValueProvider(): array
     {
-        $responses = ['q1' => 'a2', 'q2' => 'a1'];
+        $responses = ['q1' => 'a2', 'q2' => 'a1', 'Question 3 (i.e. foo bar)' => 'a1'];
 
         return [
             'no transformations' => [null, $responses, $responses],


### PR DESCRIPTION
## Overview
<!-- 
Provide a brief overview of your changes. Focus on technical aspects -- the JIRA ticket # should be in your title, so people can refer to that for functional requirements.

A screenshot is worth a thousand words -- pictures of UI changes are really good to include.

When you open the PR, create it as a draft pull request if you aren't done & don't want changes merged. Opening your PR early is a great way to get feedback before you've gone too far down a path!
-->
The Formio builder lets you enter something like "Foo bar. Baz!" as the question's value.

When validations, dynamic-forms uses the value to build the path (surveyComponentKey.questionValue), so having the dots makes it think the data is nested more than it actually is in the submission.

This PR fixes that by slugging the question values internally, but it should not impact the output.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [ ] `tests/` added or updated
- [ ] CHANGELOG.md's *Unreleased* section is updated
- [ ] Documentation is updated
