### PR TITLE
Textarea Editor Bugfix

### DIFF
--- a/src/Components/Inputs/Textarea.php
+++ b/src/Components/Inputs/Textarea.php
@@ -3,6 +3,7 @@
 namespace Northwestern\SysDev\DynamicForms\Components\Inputs;
 
 use Illuminate\Support\Arr;
+use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
 
 class Textarea extends Textfield
 {
@@ -39,8 +40,19 @@ class Textarea extends Textfield
         parent::__construct($key, $label, $errorLabel, $components, $validations, $hasMultipleValues, $conditional, $customConditional, $case, $calculateValue, $defaultValue, $additional);
 
         $editor = Arr::get($this->additional, 'editor');
-        if (! in_array($editor, self::SUPPORTED_EDITORS)) {
+
+        if ($editor === "") {
             Arr::set($this->additional, 'editor', self::EDITOR_QUILL);
+        }
+
+        if (! in_array($editor, self::SUPPORTED_EDITORS)) {
+            $message = sprintf(
+                'Unsupported editor "%s", must be [%s]',
+                $editor,
+                implode(', ', self::SUPPORTED_EDITORS)
+            );
+
+            throw new InvalidDefinitionError($message, 'editor');
         }
     }
 }

--- a/src/Components/Inputs/Textarea.php
+++ b/src/Components/Inputs/Textarea.php
@@ -41,7 +41,7 @@ class Textarea extends Textfield
 
         $editor = Arr::get($this->additional, 'editor');
 
-        if ($editor === "") {
+        if ($editor === '') {
             Arr::set($this->additional, 'editor', self::EDITOR_QUILL);
         }
 

--- a/src/Components/Inputs/Textarea.php
+++ b/src/Components/Inputs/Textarea.php
@@ -3,7 +3,6 @@
 namespace Northwestern\SysDev\DynamicForms\Components\Inputs;
 
 use Illuminate\Support\Arr;
-use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
 
 class Textarea extends Textfield
 {
@@ -41,13 +40,7 @@ class Textarea extends Textfield
 
         $editor = Arr::get($this->additional, 'editor');
         if (! in_array($editor, self::SUPPORTED_EDITORS)) {
-            $message = sprintf(
-                'Unsupported editor "%s", must be [%s]',
-                $editor,
-                implode(', ', self::SUPPORTED_EDITORS)
-            );
-
-            throw new InvalidDefinitionError($message, 'editor');
+            Arr::set($this->additional, 'editor', self::EDITOR_QUILL);
         }
     }
 }


### PR DESCRIPTION
## Overview
<!-- 
Provide a brief overview of your changes. Focus on technical aspects -- the JIRA ticket # should be in your title, so people can refer to that for functional requirements.

A screenshot is worth a thousand words -- pictures of UI changes are really good to include.

When you open the PR, create it as a draft pull request if you aren't done & don't want changes merged. Opening your PR early is a great way to get feedback before you've gone too far down a path!
-->

This PR implements a bugfix for SOAP (CCA-1920). Occasionally the following error occurs when adding a Type Area component to a form and saving it:

`Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError: [editor] Unsupported editor "", must be [quill]`

The editor field of the component appears blank sometimes and seems to be random, so the field has been set to Quill automatically when the field is blank.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [X] `tests/` added or updated
- [X] CHANGELOG.md's *Unreleased* section is updated
- [X] Documentation is updated
