### PR TITLE
register resource with ::class now instead of instantiating new resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+- Fixing how the resource registry stores its list of resources.
 ## [v0.9.0 - 2022-08-26]
 ### Added
 - Support for Resources within the Select component.

--- a/src/ResourceRegistry.php
+++ b/src/ResourceRegistry.php
@@ -39,9 +39,9 @@ class ResourceRegistry
     /**
      * Registers a resource class.
      *
-     * @param ResourceInterface $resource
+     * @param string $resource
      */
-    public function register(ResourceInterface $resource): void
+    public function register(string $resource): void
     {
         $this->resources[$resource::indexName()] = $resource;
     }

--- a/tests/Components/Inputs/SelectTest.php
+++ b/tests/Components/Inputs/SelectTest.php
@@ -164,8 +164,7 @@ class SelectTest extends InputComponentTestCase
             ]
         );
         $resourceRegistry = $this->app->make(ResourceRegistry::class);
-        $resource = new TestResource();
-        $resourceRegistry->register($resource);
+        $resourceRegistry->register(TestResource::class);
         $resourcesComponent->setResourceRegistry($resourceRegistry);
 
         $this->assertArrayHasKey(TestResource::INDEX_NAME, $resourceRegistry->registered());


### PR DESCRIPTION
## Overview
When registering resources, the registry expected you to pass them using a new instance.
`->register(new Resource())`
This would then add the classpath to the internal array of resources.
However, this would then break the registry's get method as
`->get('resource')` returned an object rather than a string.

One solution would be to change the return type of get() to string|object, but I think this is more in-line with what we do with the ComponentRegistry.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [x] `tests/` added or updated
- [x] CHANGELOG.md's *Unreleased* section is updated
- [x] Documentation is updated
