### PR TITLE
SOAP-196 Select dropdown bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+### Fixed
+- The `Select` component's `initSrcValues()` method has been updated by setting an empty array for dropdowns that lack options instead of `null`.
+
 ## [v0.11.0 - 2023-01-09]
 ### Added
 - The `Button` component has a new method, `action()` which exposes the button's action type.

--- a/src/Components/Inputs/Select.php
+++ b/src/Components/Inputs/Select.php
@@ -68,7 +68,7 @@ class Select extends BaseComponent implements ResourceValues
         $this->dataSource = Arr::get($this->additional, 'dataSrc', self::DATA_SRC_VALUES);
 
         match ($this->dataSource) {
-            self::DATA_SRC_VALUES => $this->initSrcValues($additional),
+            self::DATA_SRC_VALUES => $this->initSrcValues(),
             default => $this->initSrcOther(),
         };
     }
@@ -145,9 +145,9 @@ class Select extends BaseComponent implements ResourceValues
         return $this->optionValuesWithLabels;
     }
 
-    private function initSrcValues(array $additional): void
+    private function initSrcValues(): void
     {
-        $options = collect($this->additional['data']['values']);
+        $options = collect(Arr::get($this->additional, 'data.values', []));
 
         $this->optionValues = $options
             ->map(function (array $pair) {

--- a/tests/Components/Inputs/SelectTest.php
+++ b/tests/Components/Inputs/SelectTest.php
@@ -28,6 +28,17 @@ class SelectTest extends InputComponentTestCase
     ];
 
     /**
+     * @covers ::validate
+     */
+    public function testWithNoValuesProvided(): void
+    {
+        $component = $this->getComponent(additional: ['data' => null]);
+
+        $bag = $component->validate();
+        $this->assertEquals(true, $bag->isEmpty());
+    }
+
+    /**
      * @covers ::processValidations
      * @covers ::validate
      */


### PR DESCRIPTION
## Overview
<!-- 
Provide a brief overview of your changes. Focus on technical aspects -- the JIRA ticket # should be in your title, so people can refer to that for functional requirements.

A screenshot is worth a thousand words -- pictures of UI changes are really good to include.

When you open the PR, create it as a draft pull request if you aren't done & don't want changes merged. Opening your PR early is a great way to get feedback before you've gone too far down a path!
-->

This PR implements a fix related to the SOAP's form builder. The Select component's `initSrcValues()` method is updated by setting an empty array for dropdowns that lack options instead of `null`, thereby preventing an error due to a missing `data` key.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [X] `tests/` added or updated
- [X] CHANGELOG.md's *Unreleased* section is updated
- [X] Documentation is updated
