### PR TITLE
SOAP-539 Unable to validate some components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
-## Fixes
+### Fixes
 - `BaseComponent::submissionValue()`, which provides the method for most components, will handle multiple-value components more elegantly and should never return a `null` for them, even if this is what was represented in the submission JSON.
 
 ## [v0.15.0 - 2024-03-05]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+## Fixes
+- `BaseComponent::submissionValue()`, which provides the method for most components, will handle multiple-value components more elegantly and should never return a `null` for them, even if this is what was represented in the submission JSON.
+
 ## [v0.15.0 - 2024-03-05]
 ### Breaking Change
 - The `ResourceInterface::submissions` method signature now includes an optional `$context` parameter. To migrate, ensure that all custom resources classes incorporate the new parameter.

--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -162,6 +162,7 @@ abstract class BaseComponent implements ComponentInterface
             return $bag;
         }
 
+        // Some components made up of sub-components can have a null submission value
         if ($this->hasMultipleValuesForValidation() && ! is_null($this->submissionValue())) {
             foreach ($this->submissionValue() as $index => $submissionValue) {
                 $bag = $this->mergeErrorBags($bag, $this->processValidations(

--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -162,7 +162,7 @@ abstract class BaseComponent implements ComponentInterface
             return $bag;
         }
 
-        if ($this->hasMultipleValuesForValidation() && !is_null($this->submissionValue())) {
+        if ($this->hasMultipleValuesForValidation() && ! is_null($this->submissionValue())) {
             foreach ($this->submissionValue() as $index => $submissionValue) {
                 $bag = $this->mergeErrorBags($bag, $this->processValidations(
                     $this->key(),

--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -137,13 +137,17 @@ abstract class BaseComponent implements ComponentInterface
 
     public function submissionValue(): mixed
     {
-        $value = $this->submissionValue;
+        $cleaner = function (mixed $value) {
+            foreach ($this->transformations() as $transform) {
+                $value = $transform($value);
+            }
 
-        foreach ($this->transformations() as $transform) {
-            $value = $transform($value);
-        }
+            return $value;
+        };
 
-        return $value;
+        return $this->hasMultipleValues()
+            ? collect($this->submissionValue)->map($cleaner)->all()
+            : $cleaner($this->submissionValue);
     }
 
     public function setSubmissionValue(mixed $value): void
@@ -163,7 +167,7 @@ abstract class BaseComponent implements ComponentInterface
         }
 
         // Some components made up of sub-components can have a null submission value
-        if ($this->hasMultipleValuesForValidation() && ! is_null($this->submissionValue())) {
+        if ($this->hasMultipleValuesForValidation()) {
             foreach ($this->submissionValue() as $index => $submissionValue) {
                 $bag = $this->mergeErrorBags($bag, $this->processValidations(
                     $this->key(),

--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -162,7 +162,7 @@ abstract class BaseComponent implements ComponentInterface
             return $bag;
         }
 
-        if ($this->hasMultipleValuesForValidation()) {
+        if ($this->hasMultipleValuesForValidation() && !is_null($this->submissionValue())) {
             foreach ($this->submissionValue() as $index => $submissionValue) {
                 $bag = $this->mergeErrorBags($bag, $this->processValidations(
                     $this->key(),

--- a/tests/Components/TestCases/InputComponentTestCase.php
+++ b/tests/Components/TestCases/InputComponentTestCase.php
@@ -75,6 +75,21 @@ abstract class InputComponentTestCase extends BaseComponentTestCase
     }
 
     /**
+     * @covers ::processValidations
+     * @covers ::validate
+     */
+    public function testValidationsOnMultipleValuesForNullSubmissionValue()
+    {
+        $component = $this->getComponent(
+            hasMultipleValues: true,
+            submissionValue: null,
+        );
+
+        $bag = $component->validate();
+        $this->assertTrue($bag->isEmpty());
+    }
+
+    /**
      * @covers ::submissionValue
      * @dataProvider submissionValueProvider
      */


### PR DESCRIPTION
## Overview
[A recent issue occurred with SOAP](https://nuitadminsystems.atlassian.net/browse/SOAP-539) where applicants are unable to save/submit their applications due to the following error:
![Screenshot (202)](https://github.com/NIT-Administrative-Systems/dynamic-forms/assets/40612477/a56c2036-01d0-4f8e-8706-49f66f4bebee)

Adding the null check in this PR seems to fix the issue, and I can view even multivalue directory search components that seem to be causing the problems.

![Screenshot (204)](https://github.com/NIT-Administrative-Systems/dynamic-forms/assets/40612477/f5730ac5-979b-4f80-a4ed-faea508b15e5)

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [ ] `tests/` added or updated
- [ ] CHANGELOG.md's *Unreleased* section is updated
- [ ] Documentation is updated
