### PR TITLE
allow non boolean simple conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+### Fixes
+- `SimpleConditional::invoke()` would always return false for multi-value `Select` or `SelectBoxes` components. This has been corrected.
+
 ### Changed
 - The minimum versions for dependencies have changed. The new requirements are:
     - PHP 8.2

--- a/src/Conditional/SimpleConditional.php
+++ b/src/Conditional/SimpleConditional.php
@@ -3,6 +3,8 @@
 namespace Northwestern\SysDev\DynamicForms\Conditional;
 
 use Illuminate\Support\Arr;
+use Northwestern\SysDev\DynamicForms\Components\Inputs\Select;
+use Northwestern\SysDev\DynamicForms\Components\Inputs\SelectBoxes;
 
 class SimpleConditional implements ConditionalInterface
 {
@@ -18,8 +20,25 @@ class SimpleConditional implements ConditionalInterface
     {
         $value = Arr::get($submissionValues, $this->when);
 
-        return ($value === $this->equalTo || $value[$this->equalTo])
-            ? $this->show
-            : ! $this->show;
+
+        // Handle all regular cases
+        if ($value === $this->equalTo) {
+            return $this->show;
+        }
+
+        // Handle submissionValues with other formats
+        if (is_array($value)) {
+            /** Handles @see SelectBoxes */
+            if (isset($value[$this->equalTo]) && $value[$this->equalTo]) {
+                return $this->show;
+            }
+
+            /** Handles @see Select */
+            if (!isset($value[$this->equalTo]) && in_array($this->equalTo, $value)) {
+                return $this->show;
+            }
+        }
+
+        return !$this->show;
     }
 }

--- a/src/Conditional/SimpleConditional.php
+++ b/src/Conditional/SimpleConditional.php
@@ -20,7 +20,6 @@ class SimpleConditional implements ConditionalInterface
     {
         $value = Arr::get($submissionValues, $this->when);
 
-
         // Handle all regular cases
         if ($value === $this->equalTo) {
             return $this->show;
@@ -34,11 +33,11 @@ class SimpleConditional implements ConditionalInterface
             }
 
             /** Handles @see Select */
-            if (!isset($value[$this->equalTo]) && in_array($this->equalTo, $value)) {
+            if (! isset($value[$this->equalTo]) && in_array($this->equalTo, $value)) {
                 return $this->show;
             }
         }
 
-        return !$this->show;
+        return ! $this->show;
     }
 }

--- a/src/Conditional/SimpleConditional.php
+++ b/src/Conditional/SimpleConditional.php
@@ -18,7 +18,7 @@ class SimpleConditional implements ConditionalInterface
     {
         $value = Arr::get($submissionValues, $this->when);
 
-        return ($value === $this->equalTo)
+        return ($value === $this->equalTo || $value[$this->equalTo])
             ? $this->show
             : ! $this->show;
     }

--- a/tests/Conditional/SimpleConditionalTest.php
+++ b/tests/Conditional/SimpleConditionalTest.php
@@ -57,6 +57,18 @@ final class SimpleConditionalTest extends TestCase
                 'submissionValues' => [],
                 'expected' => false,
             ],
+            'Custom values handled' => [
+                'show' => true,
+                'when' => 'otherField',
+                'equalTo' => 'Yes',
+                'submissionValues' => [
+                    'otherField' => [
+                        'Yes' => true,
+                        'No' => false
+                    ]
+                ],
+                'expected' => true,
+            ],
         ];
     }
 }

--- a/tests/Conditional/SimpleConditionalTest.php
+++ b/tests/Conditional/SimpleConditionalTest.php
@@ -57,7 +57,7 @@ final class SimpleConditionalTest extends TestCase
                 'submissionValues' => [],
                 'expected' => false,
             ],
-            'Custom values handled' => [
+            'Select boxes values handled' => [
                 'show' => true,
                 'when' => 'otherField',
                 'equalTo' => 'Yes',
@@ -65,6 +65,17 @@ final class SimpleConditionalTest extends TestCase
                     'otherField' => [
                         'Yes' => true,
                         'No' => false,
+                    ],
+                ],
+                'expected' => true,
+            ],
+            'Select dropdown values handled' => [
+                'show' => true,
+                'when' => 'otherField',
+                'equalTo' => 'Yes',
+                'submissionValues' => [
+                    'otherField' => [
+                        'Yes'
                     ],
                 ],
                 'expected' => true,

--- a/tests/Conditional/SimpleConditionalTest.php
+++ b/tests/Conditional/SimpleConditionalTest.php
@@ -75,7 +75,7 @@ final class SimpleConditionalTest extends TestCase
                 'equalTo' => 'Yes',
                 'submissionValues' => [
                     'otherField' => [
-                        'Yes'
+                        'Yes',
                     ],
                 ],
                 'expected' => true,

--- a/tests/Conditional/SimpleConditionalTest.php
+++ b/tests/Conditional/SimpleConditionalTest.php
@@ -64,8 +64,8 @@ final class SimpleConditionalTest extends TestCase
                 'submissionValues' => [
                     'otherField' => [
                         'Yes' => true,
-                        'No' => false
-                    ]
+                        'No' => false,
+                    ],
                 ],
                 'expected' => true,
             ],


### PR DESCRIPTION
## Overview
Previously, the SimpleConditional logic only checked for an array key and its value, i.e.
```php
[
  'when' => 'key',
  'equalTo' => 'value',
  'show' => true
]
```
for formio data like:
```php
[
  'submissionValues' => [
    'key' => 'value'
  ]
]
```
However, `SelectBoxes` and `Select` with the multivalue option enabled format their values differently, leading to `SimpleConditional::invoke()` always returning false and the components' values being ignored during validations. An example in SOAP is, because the values of these ignored components are not persisted, missing PDF uploads:
![Screenshot (221)](https://github.com/NIT-Administrative-Systems/dynamic-forms/assets/40612477/189333f9-1081-46db-80f8-ae37bc87f7cb)


This PR expands the SimpleConditional logic to cover these cases, handling the following:
```php
// SelectBoxes tracks each selected option by setting the corresponding key to true
'submissionValues' => [
    'key' => [
        'option1' => true,
        'option2' => false,
    ],
],
```
and
```php
// multivalue Select components track each selected option via an array of selected option keys
'submissionValues' => [
    'key' => [
        'option1', 'option2'
    ],
],
```

So now all the conditionals shown below just work(tm), and values will be persisted.
![aaaaaaa](https://github.com/NIT-Administrative-Systems/dynamic-forms/assets/40612477/00b85436-60b1-445b-b918-011de59f687d)

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [x] `tests/` added or updated
- [x] CHANGELOG.md's *Unreleased* section is updated
- [x] Documentation is updated
