### PR TITLE
Support JSON Logic Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Breaking Change
+- The `ComponentInterface` has a new method, `advancedValidations()` which returns an invokable `ValidationInterface` instance.
+### Added
+- Support for JSON Logic into the component validation process.
 ### Fixes
 - Fixed an issue where the `Currency` component failed validation when not required and given null values.
+- Fixed an instance where the `$subject` parameter to `str_replace()` could have been null in `Textfield::processValidations()`, as this was deprecated in PHP 8.1.
 
 ## [v1.0.1] 2024-05-15
 ### Changed

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ There are a couple pieces to be aware of:
 - **Forms** are shown when you render a form definition. The form can be read-write or read-only (to display a submitted form). Forms produce submissions in the form of key:value JSON documents.
 
 ## Supported Features
-Formiojs offers a lot of functionality. Dynamic Forms for Laravel has implemented a limited subset of all its available features.
+Formiojs offers a lot of functionality. Dynamic Forms for Laravel has implemented a limited subset of all its available features, including JSON Logic support for complex conditions to show/hide fields, calculate values, and validate data.
 
 Most of the decisions not to include something were driven by what would give us a good minimum viable product. If there are missing features that you would like to see, please feel free to submit an issue to discuss including it.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,5 +1,14 @@
 # Upgrading
 
+## v1.1.0
+This version adds a new `advancedValidations()` method to the `ComponentInterface`.
+
+```php
+public function advancedValidations(): ?ValidationInterface;
+```
+
+If you have implemented this interface, you should update your implementations.
+
 ## v1.0.0
 This version swaps to the Formiojs v5 release candidate and assumes Bootstrap v5 and FontAwesome 6 are in use. The package now assumes Laravel 11, Laravel Vite, and PHP 8.2+.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,7 +7,7 @@ This version adds a new `advancedValidations()` method to the `ComponentInterfac
 public function advancedValidations(): ?ValidationInterface;
 ```
 
-If you have implemented this interface, you should update your implementations.
+This is implemented in the `BaseComponent`. However, if you have implemented this interface elsewhere, you should update your implementations.
 
 ## v1.0.0
 This version swaps to the Formiojs v5 release candidate and assumes Bootstrap v5 and FontAwesome 6 are in use. The package now assumes Laravel 11, Laravel Vite, and PHP 8.2+.

--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -11,12 +11,12 @@ use Northwestern\SysDev\DynamicForms\Calculation\JSONCalculation;
 use Northwestern\SysDev\DynamicForms\Conditional\ConditionalInterface;
 use Northwestern\SysDev\DynamicForms\Conditional\JSONConditional;
 use Northwestern\SysDev\DynamicForms\Conditional\SimpleConditional;
-use Northwestern\SysDev\DynamicForms\Validation\JSONValidation;
-use Northwestern\SysDev\DynamicForms\Validation\ValidationInterface;
 use Northwestern\SysDev\DynamicForms\Errors\CalculationNotImplemented;
 use Northwestern\SysDev\DynamicForms\Errors\ConditionalNotImplemented;
 use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
 use Northwestern\SysDev\DynamicForms\Errors\ValidationNotImplementedError;
+use Northwestern\SysDev\DynamicForms\Validation\JSONValidation;
+use Northwestern\SysDev\DynamicForms\Validation\ValidationInterface;
 
 /**
  * Implements common functionality for all components.

--- a/src/Components/BaseComponent.php
+++ b/src/Components/BaseComponent.php
@@ -11,6 +11,8 @@ use Northwestern\SysDev\DynamicForms\Calculation\JSONCalculation;
 use Northwestern\SysDev\DynamicForms\Conditional\ConditionalInterface;
 use Northwestern\SysDev\DynamicForms\Conditional\JSONConditional;
 use Northwestern\SysDev\DynamicForms\Conditional\SimpleConditional;
+use Northwestern\SysDev\DynamicForms\Validation\JSONValidation;
+use Northwestern\SysDev\DynamicForms\Validation\ValidationInterface;
 use Northwestern\SysDev\DynamicForms\Errors\CalculationNotImplemented;
 use Northwestern\SysDev\DynamicForms\Errors\ConditionalNotImplemented;
 use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
@@ -280,6 +282,15 @@ abstract class BaseComponent implements ComponentInterface
     public function validations(): array
     {
         return $this->validations;
+    }
+
+    public function advancedValidations(): ?ValidationInterface
+    {
+        if ($this->validation('json')) {
+            return new JSONValidation($this->validation('json'));
+        }
+
+        return null;
     }
 
     public function additional(string $key): mixed

--- a/src/Components/ComponentInterface.php
+++ b/src/Components/ComponentInterface.php
@@ -5,6 +5,7 @@ namespace Northwestern\SysDev\DynamicForms\Components;
 use Illuminate\Contracts\Support\MessageBag;
 use Northwestern\SysDev\DynamicForms\Calculation\CalculationInterface;
 use Northwestern\SysDev\DynamicForms\Conditional\ConditionalInterface;
+use Northwestern\SysDev\DynamicForms\Validation\ValidationInterface;
 
 interface ComponentInterface
 {
@@ -139,6 +140,11 @@ interface ComponentInterface
      * Get all validations for the component.
      */
     public function validations(): array;
+
+    /**
+     * Returns an invokable Validation instance.
+     */
+    public function advancedValidations(): ?ValidationInterface;
 
     /**
      * Get other settings that are not used directly by the library, but may be present in the component schema.

--- a/src/Components/Inputs/Textfield.php
+++ b/src/Components/Inputs/Textfield.php
@@ -27,9 +27,11 @@ class Textfield extends BaseComponent
             $rules->add(new CheckWordCount(CheckWordCount::MODE_MAXIMUM, $this->validation('maxWords')));
         }
 
-        // PHP needs the regexp armoured with slashes, so...
-        $pattern = sprintf('/%s/', str_replace('/', '\/', $this->validation('pattern')));
-        $rules->addIfNotNull(['regex', $pattern], $this->validation('pattern'));
+        if ($this->validation('pattern')) {
+            // PHP needs the regexp armoured with slashes, so...
+            $pattern = sprintf('/%s/', str_replace('/', '\/', $this->validation('pattern')));
+            $rules->add(['regex', $pattern], $this->validation('pattern'));
+        }
 
         return $validator->make(
             [$fieldKey => $submissionValue],

--- a/src/Forms/ValidatedForm.php
+++ b/src/Forms/ValidatedForm.php
@@ -39,6 +39,9 @@ class ValidatedForm implements Validator
 
         foreach ($this->flatComponents as $component) {
             $messageBag->merge($component->validate());
+            if ($component->advancedValidations()) {
+                $messageBag->merge($component->advancedValidations()($component, $this->valuesWhileProcessingForm()));
+            }
             $transformedValues->put($component->key(), $component->submissionValue());
         }
 

--- a/src/Validation/JSONValidation.php
+++ b/src/Validation/JSONValidation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Northwestern\SysDev\DynamicForms\Validation;
+
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\MessageBag as MessageBagImpl;
+use JWadhams\JsonLogic;
+use Northwestern\SysDev\DynamicForms\Components\ComponentInterface;
+use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
+use Northwestern\SysDev\DynamicForms\JSONLogic\JsonLogicHelpers;
+
+class JSONValidation implements ValidationInterface
+{
+    protected array $jsonLogic;
+
+    public function __construct(array $jsonLogic)
+    {
+        $this->jsonLogic = JsonLogicHelpers::convertDataVars($jsonLogic);
+    }
+
+    public function __invoke(ComponentInterface $component, array $submissionValues): MessageBag
+    {
+        $bag = new MessageBagImpl;
+
+        if (! $this->isValidCustomValidation($this->jsonLogic)) {
+            throw new InvalidDefinitionError(
+                'Custom JSON Logic validations must always use the "if" parameter. The first argument to the statement must be the "true" case, and the second should be the error to display if the validation fails.',
+                $component->key(),
+            );
+        }
+
+        $validationResult = JsonLogic::apply($this->jsonLogic, $submissionValues);
+
+        if ($validationResult !== true) {
+            $bag->add($component->key(), $validationResult);
+        }
+
+        return $bag;
+    }
+
+    /**
+     * Custom JSON Logic validations must always use the "if" parameter. The first argument to the statement
+     * must be the "true" case, and the second should be the error to display if the validation fails.
+     *
+     * {@link https://help.form.io/developers/form-development/form-evaluations#custom-validation-1}
+     */
+    protected function isValidCustomValidation(array $jsonLogic): bool
+    {
+        return isset($jsonLogic['if']) &&
+            is_array($jsonLogic['if']) &&
+            count($jsonLogic['if']) === 3;
+    }
+}

--- a/src/Validation/ValidationInterface.php
+++ b/src/Validation/ValidationInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Northwestern\SysDev\DynamicForms\Validation;
+
+use Illuminate\Contracts\Support\MessageBag;
+use Northwestern\SysDev\DynamicForms\Components\ComponentInterface;
+
+interface ValidationInterface
+{
+    public function __invoke(ComponentInterface $component, array $submissionValues): MessageBag;
+}

--- a/tests/Components/TestCases/BaseComponentTestCase.php
+++ b/tests/Components/TestCases/BaseComponentTestCase.php
@@ -43,6 +43,7 @@ abstract class BaseComponentTestCase extends TestCase
      * @covers ::defaultValue
      * @covers ::validation
      * @covers ::validations
+     * @covers ::advancedValidations
      */
     public function testGetters(): void
     {
@@ -62,6 +63,7 @@ abstract class BaseComponentTestCase extends TestCase
         $this->assertEquals('foo', $component->defaultValue());
         $this->assertNull($component->validation('required'));
         $this->assertEmpty($component->validations());
+        $this->assertNull($component->advancedValidations());
         $this->assertTrue($component->additional('disabled'));
     }
 

--- a/tests/Validation/JSONValidationTest.php
+++ b/tests/Validation/JSONValidationTest.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 final class JSONValidationTest extends TestCase
 {
+    private const DATE_EXPECT_FAIL = true;
+    private const DATE_EXPECT_PASS = false;
+
     /**
      * @param  array|class-string  $expected
      *
@@ -56,6 +59,7 @@ final class JSONValidationTest extends TestCase
     public static function invokeDataProvider(): array
     {
         return [
+            ...self::dataFuzzerProvider(),
             'should throw exception when "if" parameter is missing' => [
                 'jsonValidation' => json_decode('{
                     "json": {
@@ -404,6 +408,69 @@ final class JSONValidationTest extends TestCase
                 'expected' => [],
             ],
         ];
+    }
+
+    public static function dataFuzzerProvider(): array
+    {
+        $rule = json_decode('{
+            "json": {
+                "if": [
+                    {
+                        "<=": [
+                            { "var": "startsAt" },
+                            { "var": "endsAt" }
+                        ]
+                    },
+                    true,
+                    "The absence end date cannot be earlier than the absence start date."
+                ]
+            }
+        }', true);
+
+        return collect([
+            // startsAt, endsAt, expectedToFail (bool)
+            'should handle dates like the client-side code, fail with custom error message' => [
+                '2024-10-05T05:00:00.000000Z',
+                '2024-10-01T05:00:00.000000Z',
+                self::DATE_EXPECT_FAIL,
+            ],
+            'should handle dates like the client-side code, pass' => [
+                '2024-10-01T05:00:00.000000Z',
+                '2024-10-05T05:00:00.000000Z',
+                self::DATE_EXPECT_PASS,
+            ],
+            ...collect(range(1, 12))->mapWithKeys(function (int $month) {
+                $month = str_pad($month, '0', STR_PAD_LEFT);
+
+                return [
+                    "should handle dates like the client-side code, pass with static low-end date vs 2024-{$month}-XX" => [
+                        '2024-01-01T05:00:00.000000Z',
+                        "2024-{$month}-05T05:00:00.000000Z",
+                        self::DATE_EXPECT_PASS,
+                    ],
+                    "should handle dates like the client-side code, fail with static low-end date vs 2024-{$month}-XX" => [
+                        '2024-01-05T05:00:00.000000Z',
+                        "2024-{$month}-02T05:00:00.000000Z",
+                        self::DATE_EXPECT_FAIL,
+                    ],
+                ];
+            })->all(),
+            'should handle dates like the client-side code, pass with high month' => [
+                '2024-01-01T05:00:00.000000Z',
+                '2024-10-05T05:00:00.000000Z',
+                self::DATE_EXPECT_PASS,
+            ],
+        ])->map(function (array $data) use ($rule): array {
+            [$startsAt, $endsAt, $expectedToFail] = $data;
+
+            return [
+                'jsonValidation' => $rule,
+                'submissionValues' => ['startsAt' => $startsAt, 'endsAt' => $endsAt],
+                'expected' => $expectedToFail
+                    ? ['The absence end date cannot be earlier than the absence start date.']
+                    : [],
+            ];
+        })->all();
     }
 
     private function getComponent(

--- a/tests/Validation/JSONValidationTest.php
+++ b/tests/Validation/JSONValidationTest.php
@@ -1,0 +1,427 @@
+<?php
+
+namespace Northwestern\SysDev\DynamicForms\Tests\Validation;
+
+use Northwestern\SysDev\DynamicForms\Components\ComponentInterface;
+use Northwestern\SysDev\DynamicForms\Components\Inputs\Textfield;
+use Northwestern\SysDev\DynamicForms\Errors\InvalidDefinitionError;
+use Northwestern\SysDev\DynamicForms\JSONLogicInitHelper;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @coversDefaultClass \Northwestern\SysDev\DynamicForms\Validation\JSONValidation
+ */
+final class JSONValidationTest extends TestCase
+{
+    #[DataProvider('invokeDataProvider')]
+    /**
+     * @param  array|class-string  $expected
+     */
+    public function testInvoke(array $jsonValidation, array $submissionValues, array|string $expected): void
+    {
+        ray()->clearAll();
+        new JSONLogicInitHelper;
+
+        $component = $this->getComponent(validations: $jsonValidation);
+
+        if (is_string($expected) && class_exists($expected)) {
+            $this->expectException($expected);
+        }
+
+        $result = $component->advancedValidations()($component, $submissionValues);
+
+        if (empty($expected)) {
+            $this->assertTrue($result->isEmpty(), 'Expected no validation errors, but some were found.');
+        } else {
+            foreach ($expected as $field => $messages) {
+                $this->assertTrue(
+                    $result->has($field),
+                    "Expected validation error for field '{$field}'."
+                );
+                foreach ($messages as $message) {
+                    $this->assertContains(
+                        $message,
+                        $result->get($field),
+                        "Expected message '{$message}' for field '{$field}'."
+                    );
+                }
+            }
+
+            $this->assertCount(count($expected), $result->all());
+        }
+    }
+
+    public static function invokeDataProvider(): array
+    {
+        return [
+            'should throw exception when "if" parameter is missing' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "===": [
+                            {
+                                "var": "foo"
+                            },
+                            "bar"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'foo'],
+                'expected' => InvalidDefinitionError::class,
+            ],
+            'should throw exception when "if" parameter has less than three arguments' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, "bar" ] },
+                            true
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'baz'],
+                'expected' => InvalidDefinitionError::class,
+            ],
+            'should throw exception when "if" parameter has more than three arguments' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Values must be equal",
+                            "Extra argument"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'baz'],
+                'expected' => InvalidDefinitionError::class,
+            ],
+            'should throw exception when "if" condition is not an array' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": "not an array"
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'baz'],
+                'expected' => InvalidDefinitionError::class,
+            ],
+            'should fail when values are not equal with custom message' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Values must be equal"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'foo'],
+                'expected' => [
+                    'test' => [
+                        'Values must be equal',
+                    ],
+                ],
+            ],
+            'should pass when values are equal' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Values must be equal"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'bar'],
+                'expected' => [],
+            ],
+            'should fail when values are equal with custom message' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "!==": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Values must not be equal"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'bar'],
+                'expected' => [
+                    'test' => [
+                        'Values must not be equal',
+                    ],
+                ],
+            ],
+            'should pass when values are not equal' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "!==": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Values must not be equal"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'baz'],
+                'expected' => [],
+            ],
+            'should fail when value is not in the list with custom message' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "in": [ { "var": "foo" }, ["bar", "baz"] ] },
+                            true,
+                            "Value must be either bar or baz"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'qux'],
+                'expected' => [
+                    'test' => [
+                        'Value must be either bar or baz',
+                    ],
+                ],
+            ],
+            'should pass when value is in the list' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "in": [ { "var": "foo" }, ["bar", "baz"] ] },
+                            true,
+                            "Value must be either bar or baz"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'bar'],
+                'expected' => [],
+            ],
+            'should fail when value is not greater than the threshold with custom message' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { ">": [ { "var": "foo" }, 10 ] },
+                            true,
+                            "Value must be greater than 10"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 5],
+                'expected' => [
+                    'test' => [
+                        'Value must be greater than 10',
+                    ],
+                ],
+            ],
+            'should pass when value is greater than the threshold' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { ">": [ { "var": "foo" }, 10 ] },
+                            true,
+                            "Value must be greater than 10"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 15],
+                'expected' => [],
+            ],
+            'should fail when value is not less than the threshold with custom message' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "<": [ { "var": "foo" }, 20 ] },
+                            true,
+                            "Value must be less than 20"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 25],
+                'expected' => [
+                    'test' => [
+                        'Value must be less than 20',
+                    ],
+                ],
+            ],
+            'should pass when value is less than the threshold' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "<": [ { "var": "foo" }, 20 ] },
+                            true,
+                            "Value must be less than 20"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 15],
+                'expected' => [],
+            ],
+            'should fail multiple fields with custom messages' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Foo must be equal to bar"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'baz'],
+                'expected' => [
+                    'test' => [
+                        'Foo must be equal to bar',
+                    ],
+                ],
+            ],
+            'should handle nested conditions and fail with custom message' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            {
+                                "and": [
+                                    { "===": [ { "var": "foo" }, "bar" ] },
+                                    { ">": [ { "var": "baz" }, 10 ] }
+                                ]
+                            },
+                            true,
+                            "Foo must be bar and baz must be greater than 10"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'bar', 'baz' => 5],
+                'expected' => [
+                    'test' => [
+                        'Foo must be bar and baz must be greater than 10',
+                    ],
+                ],
+            ],
+            'should handle nested conditions and pass when all conditions are met' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            {
+                                "and": [
+                                    { "===": [ { "var": "foo" }, "bar" ] },
+                                    { ">": [ { "var": "baz" }, 10 ] }
+                                ]
+                            },
+                            true,
+                            "Foo must be bar and baz must be greater than 10"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'bar', 'baz' => 15],
+                'expected' => [],
+            ],
+            'should fail when submissionValues is empty' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Foo must be bar"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => [],
+                'expected' => [
+                    'test' => [
+                        'Foo must be bar',
+                    ],
+                ],
+            ],
+            'should fail when submissionValues is null' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, "bar" ] },
+                            true,
+                            "Foo must be bar"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => null],
+                'expected' => [
+                    'test' => [
+                        'Foo must be bar',
+                    ],
+                ],
+            ],
+            'should handle non-string values correctly' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            { "===": [ { "var": "foo" }, 100 ] },
+                            true,
+                            "Foo must be 100"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => '100'],
+                'expected' => [
+                    'test' => [
+                        'Foo must be 100',
+                    ],
+                ],
+            ],
+            'should handle complex logical operators and fail with custom message' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            {
+                                "and": [
+                                    { "===": [ { "var": "foo" }, "bar" ] },
+                                    { "===": [ { "var": "baz" }, "qux" ] }
+                                ]
+                            },
+                            true,
+                            "Foo must be bar and Baz must be qux"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'bar', 'baz' => 'not_qux'],
+                'expected' => [
+                    'test' => [
+                        'Foo must be bar and Baz must be qux',
+                    ],
+                ],
+            ],
+            'should handle complex logical operators and pass when all conditions are met' => [
+                'jsonValidation' => json_decode('{
+                    "json": {
+                        "if": [
+                            {
+                                "and": [
+                                    { "===": [ { "var": "foo" }, "bar" ] },
+                                    { "===": [ { "var": "baz" }, "qux" ] }
+                                ]
+                            },
+                            true,
+                            "Foo must be bar and Baz must be qux"
+                        ]
+                    }
+                }', true),
+                'submissionValues' => ['foo' => 'bar', 'baz' => 'qux'],
+                'expected' => [],
+            ],
+        ];
+    }
+
+    private function getComponent(
+        array $validations = [],
+    ): ComponentInterface {
+        /** @var ComponentInterface $component */
+        return new Textfield(
+            key: 'test',
+            label: 'Test',
+            errorLabel: null,
+            components: [],
+            validations: $validations,
+            hasMultipleValues: false,
+            conditional: null,
+            customConditional: null,
+            case: 'mixed',
+            calculateValue: null,
+            defaultValue: null,
+            additional: [],
+        );
+    }
+}

--- a/tests/Validation/JSONValidationTest.php
+++ b/tests/Validation/JSONValidationTest.php
@@ -14,13 +14,14 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 final class JSONValidationTest extends TestCase
 {
-    #[DataProvider('invokeDataProvider')]
     /**
      * @param  array|class-string  $expected
+     *
+     * @covers ::isValidCustomValidation
      */
+    #[DataProvider('invokeDataProvider')]
     public function testInvoke(array $jsonValidation, array $submissionValues, array|string $expected): void
     {
-        ray()->clearAll();
         new JSONLogicInitHelper;
 
         $component = $this->getComponent(validations: $jsonValidation);

--- a/tests/Validation/JSONValidationTest.php
+++ b/tests/Validation/JSONValidationTest.php
@@ -440,7 +440,7 @@ final class JSONValidationTest extends TestCase
                 self::DATE_EXPECT_PASS,
             ],
             ...collect(range(1, 12))->mapWithKeys(function (int $month) {
-                $month = str_pad($month, '0', STR_PAD_LEFT);
+                $month = str_pad($month, '1', '0', STR_PAD_LEFT);
 
                 return [
                     "should handle dates like the client-side code, pass with static low-end date vs 2024-{$month}-XX" => [
@@ -448,9 +448,9 @@ final class JSONValidationTest extends TestCase
                         "2024-{$month}-05T05:00:00.000000Z",
                         self::DATE_EXPECT_PASS,
                     ],
-                    "should handle dates like the client-side code, fail with static low-end date vs 2024-{$month}-XX" => [
-                        '2024-01-05T05:00:00.000000Z',
+                    "should handle dates like the client-side code, fail with static high-end date vs 2024-{$month}-XX" => [
                         "2024-{$month}-02T05:00:00.000000Z",
+                        '2024-01-01T05:00:00.000000Z',
                         self::DATE_EXPECT_FAIL,
                     ],
                 ];
@@ -467,7 +467,7 @@ final class JSONValidationTest extends TestCase
                 'jsonValidation' => $rule,
                 'submissionValues' => ['startsAt' => $startsAt, 'endsAt' => $endsAt],
                 'expected' => $expectedToFail
-                    ? ['The absence end date cannot be earlier than the absence start date.']
+                    ? ['test' => ['The absence end date cannot be earlier than the absence start date.']]
                     : [],
             ];
         })->all();


### PR DESCRIPTION
## Overview
<!-- 
Provide a brief overview of your changes. Focus on technical aspects -- the JIRA ticket # should be in your title, so people can refer to that for functional requirements.

A screenshot is worth a thousand words -- pictures of UI changes are really good to include.

When you open the PR, create it as a draft pull request if you aren't done & don't want changes merged. Opening your PR early is a great way to get feedback before you've gone too far down a path!
-->

Adding support for JSON Logic into the component validation process.

### Fixes
- Fixed an instance where the `$subject` parameter to `str_replace()` could have been null in `Textfield::processValidations()`, as this was deprecated in PHP 8.1.

## Checklist
<!--
Run through this checklist. Check off items once you've considered them & decided you have them covered in the PR (or they are not applicable).
-->
- [x] `tests/` added or updated
- [x] CHANGELOG.md's *Unreleased* section is updated
- [x] Documentation is updated
