### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.3', '8.4']
+        php-versions: ['8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [v3.0.0] - 2026-04-06
 ### Changed
 - Requires `northwestern-sysdev/lodash-php` ^4.0.0, which removes the global `__()` function that conflicted with Laravel's `__()` (trans) helper.
+- Dropped support for Laravel 8, 9, and 10 (incompatible with PHP ^8.3 and Carbon ^3).
+- Dropped support for Symfony Finder ^6.
 ### Added
 - Updated composer requirements to support Laravel 13.
 - Added PHP 8.5 to CI test matrix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [v3.0.0] - 2026-04-06
 ### Changed
-- The minimum PHP version is now 8.4.
 - Requires `northwestern-sysdev/lodash-php` ^4.0.0, which removes the global `__()` function that conflicted with Laravel's `__()` (trans) helper.
 ### Added
 - Updated composer requirements to support Laravel 13.
+- Added PHP 8.5 to CI test matrix.
 
 ## [v2.0.0] - 2025-08-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [v3.0.0] - 2026-04-06
 ### Changed
 - The minimum PHP version is now 8.4.
+- Requires `northwestern-sysdev/lodash-php` ^4.0.0, which removes the global `__()` function that conflicted with Laravel's `__()` (trans) helper.
 ### Added
 - Updated composer requirements to support Laravel 13.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v3.0.0] - 2026-04-06
+### Changed
+- The minimum PHP version is now 8.4.
+### Added
+- Updated composer requirements to support Laravel 13.
+
 ## [v2.0.0] - 2025-08-29
 ### Changed
 - The minimum PHP version is now 8.3.
@@ -232,7 +238,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [v0.1.0] - 2021-05-04
 - Initial release.
 
-[Unreleased]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v3.0.0...HEAD
+[v3.0.0]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v2.0.0...v3.0.0
+[v2.0.0]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v1.2.2...v2.0.0
+[v1.2.2]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v1.2.1...v1.2.2
+[v1.2.1]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v1.2.0...v1.2.1
+[v1.2.0]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v1.1.0...v1.2.0
 [v1.1.0]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v1.0.1...v1.1.0
 [v1.0.1]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/NIT-Administrative-Systems/dynamic-forms/compare/v0.15.1...v1.0.0

--- a/composer.json
+++ b/composer.json
@@ -19,19 +19,19 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "aws/aws-sdk-php": "^3.80|^4",
-        "illuminate/support": "^8|^9|^10|^11|^12",
-        "illuminate/validation": "^8|^9|^10|^11|^12",
-        "illuminate/contracts": "^8|^9|^10|^11|^12",
-        "illuminate/http": "^8|^9|^10|^11|^12",
-        "symfony/finder": "^6|^7",
+        "illuminate/support": "^8|^9|^10|^11|^12|^13",
+        "illuminate/validation": "^8|^9|^10|^11|^12|^13",
+        "illuminate/contracts": "^8|^9|^10|^11|^12|^13",
+        "illuminate/http": "^8|^9|^10|^11|^12|^13",
+        "symfony/finder": "^6|^7|^8",
         "nesbot/carbon": "^3",
         "jwadhams/json-logic-php": "^1.4",
         "northwestern-sysdev/lodash-php": "^3.0.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^10",
+        "orchestra/testbench": "^11",
         "phpunit/phpunit": "^11.0",
         "php-coveralls/php-coveralls": "^2.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     "require": {
         "php": "^8.3",
         "aws/aws-sdk-php": "^3.80|^4",
-        "illuminate/support": "^8|^9|^10|^11|^12|^13",
-        "illuminate/validation": "^8|^9|^10|^11|^12|^13",
-        "illuminate/contracts": "^8|^9|^10|^11|^12|^13",
-        "illuminate/http": "^8|^9|^10|^11|^12|^13",
-        "symfony/finder": "^6|^7|^8",
+        "illuminate/support": "^11|^12|^13",
+        "illuminate/validation": "^11|^12|^13",
+        "illuminate/contracts": "^11|^12|^13",
+        "illuminate/http": "^11|^12|^13",
+        "symfony/finder": "^7|^8",
         "nesbot/carbon": "^3",
         "jwadhams/json-logic-php": "^1.4",
         "northwestern-sysdev/lodash-php": "^4.0.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/finder": "^6|^7|^8",
         "nesbot/carbon": "^3",
         "jwadhams/json-logic-php": "^1.4",
-        "northwestern-sysdev/lodash-php": "^3.0.0"
+        "northwestern-sysdev/lodash-php": "^4.0.0"
     },
     "require-dev": {
         "orchestra/testbench": "^11",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "aws/aws-sdk-php": "^3.80|^4",
         "illuminate/support": "^8|^9|^10|^11|^12|^13",
         "illuminate/validation": "^8|^9|^10|^11|^12|^13",


### PR DESCRIPTION
## Summary
- Added Laravel 13 support (`illuminate/*` `^13`, `symfony/finder` `^8`)
- Updated `orchestra/testbench` to `^11`
- Dropped Laravel 8/9/10 and Symfony Finder ^6 (already unreachable with PHP ^8.3 and Carbon ^3)
- Requires `northwestern-sysdev/lodash-php` ^4.0.0, fixing the `__()` conflict with Laravel's trans helper
- Added PHP 8.5 to CI test matrix

## Breaking Changes
- Minimum Laravel version is now 11
- Requires lodash-php ^4.0.0

Fixes #452, fixes #478, fixes #473