### PR TITLE
Bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v5
       with:
         version: 10.x.x
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,7 +16,7 @@ jobs:
         php-versions: ['8.3', '8.4']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 
@@ -28,9 +28,9 @@ jobs:
           coverage: xdebug
 
       - name: Run php-cs-fixer
-        uses: OskarStark/php-cs-fixer-ga@3.13.0
+        uses: OskarStark/php-cs-fixer-ga@3.26.0
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Apply php-cs-fixer changes
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,7 +28,7 @@ jobs:
           coverage: xdebug
 
       - name: Run php-cs-fixer
-        uses: OskarStark/php-cs-fixer-ga@3.26.0
+        uses: OskarStark/php-cs-fixer-ga@3.13.0
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -13,10 +13,10 @@ jobs:
         node-version: [24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v5
       with:
         version: 10.x.x
 


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v6
- Bump `pnpm/action-setup` from v4 to v5
- Bump `stefanzweifel/git-auto-commit-action` from v5 to v7

All updates are Node 24 runtime bumps with no breaking changes.
 Closes #483, closes #484, closes #485.