### PR TITLE
fix: Number component incorrectly uses label as validator key

### DIFF
--- a/src/Components/Inputs/Number.php
+++ b/src/Components/Inputs/Number.php
@@ -14,21 +14,21 @@ class Number extends BaseComponent
 
     protected function processValidations(string $fieldKey, string $fieldLabel, mixed $submissionValue, Factory $validator): MessageBag
     {
-        $fieldKey = $this->label() ?? $this->key();
-
         $rules = new RuleBag($fieldKey, ['numeric']);
-        $rules->addIf('required', $this->validation('required') === true);
+
+        $this->validation('required')
+            ? $rules->add('required')
+            : $rules->add('nullable');
+
         $rules->addIfNotNull(sprintf('min:%s', $this->validation('min')), $this->validation('min'));
         $rules->addIfNotNull(sprintf('max:%s', $this->validation('max')), $this->validation('max'));
 
-        $validator = app()->make('validator')->make(
+        return $validator->make(
             [$fieldKey => $submissionValue],
             $rules->rules(),
             [],
             [$fieldKey => $fieldLabel]
-        );
-
-        return $validator->messages();
+        )->messages();
     }
 
     /**

--- a/tests/Components/Inputs/NumberTest.php
+++ b/tests/Components/Inputs/NumberTest.php
@@ -20,7 +20,10 @@ final class NumberTest extends InputComponentTestCase
             'min passes' => [['min' => 10], 11, true],
             'max fails' => [['max' => 3], 4, false],
             'max passes' => [['max' => 3], 3, true],
-        ];
+            // Regression: optional number field should accept null without error
+            'optional empty passes' => [[], null, true],
+            'optional empty string passes' => [[], '', true],
+      ];
     }
 
     public static function submissionValueProvider(): array


### PR DESCRIPTION
## Problem

  The `Number` component's `processValidations` method overwrites the `$fieldKey`
  parameter with the component's label string:

`$fieldKey = $this->label() ?? $this->key();`

  This means the validator's data array is keyed by the label (e.g. "Wash Temp")
  instead of the actual FormIO field key (e.g. washTemp).

  When a user submits an empty optional number field, submissionValue() returns
  null. Laravel's Arr::has finds the label-key directly in the data (since it
  contains no dots), so the numeric rule fires on null, producing a spurious
  validation error: "The Wash Temp must be a number."

  Odd side effect: Labels ending with a dot (e.g. "Rinse Temp.") happen to
  avoid the error — Laravel's Arr::has treats dots as nested key separators, so it
  looks for data["Rinse Temp"][""] which doesn't exist, and the numeric rule
  never fires. This made the bug appear inconsistent and hard to trace.

 ## Fix

  Two changes, modelled after the existing Currency component which handles this
  correctly:

  1. Remove the $fieldKey override — use the parameter as passed in from
  BaseComponent::validate(), which is already $this->key().
  2. Add nullable for non-required fields — so that a null submission value
  does not trigger the numeric rule (same pattern as Currency).

  Tests

  Added two cases to NumberTest::validationsProvider() covering empty optional
  fields (both null and empty string).